### PR TITLE
database-manager在数据源类型为mssql，如果表comment不存在或没填写，在查询表信息并不会返回tableMeta信息…

### DIFF
--- a/hsweb-system/hsweb-system-database-manager/hsweb-system-database-manager-api/src/main/java/org/hswebframework/web/database/manager/meta/table/parser/support/SqlServerTableMetaDataParser.java
+++ b/hsweb-system/hsweb-system-database-manager/hsweb-system-database-manager-api/src/main/java/org/hswebframework/web/database/manager/meta/table/parser/support/SqlServerTableMetaDataParser.java
@@ -18,8 +18,9 @@ public class SqlServerTableMetaDataParser extends AbstractSqlTableMetaDataParser
             "left join sys.extended_properties p on c.id=p.major_id and c.colid=p.minor_id\n" +
             "WHERE c.id = object_id(#{table})";
 
-    private static String TABLE_COMMENT_SQL = "select cast(p.value as varchar(500)) as [comment] from sys.extended_properties p " +
-            " where p.major_id=object_id(#{table}) and p.minor_id=0";
+    private static String TABLE_COMMENT_SQL = "select o.name as [name], p.value as [comment] from sysobjects o " +
+            "left join sys.extended_properties p " +
+            "on p.major_id=object_id(o.name) and p.minor_id=0 where o.name=#{table} and o.xtype='U'";
 
     public SqlServerTableMetaDataParser(SqlExecutor sqlExecutor) {
         super(sqlExecutor, DatabaseType.sqlserver, DatabaseType.jtds_sqlserver);


### PR DESCRIPTION
…，原因在于sys.extended_properties表不存在表数据(即使表存在)。现将mssql的表备注查询SQL修改，利用左关联判断sysobjects表存在数据即返回数据(即使coment不存在)