### PR TITLE
fix: 优化树结构实体的保存

### DIFF
--- a/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/service/TreeSortServiceHelper.java
+++ b/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/service/TreeSortServiceHelper.java
@@ -190,7 +190,7 @@ public class TreeSortServiceHelper<E extends TreeSortSupportEntity<PK>, PK> {
             if (old != null) {
                 PK newParentId = data.getParentId();
                 //父节点发生变化，更新所有子节点path
-                if (!Objects.equals(parentId, newParentId)) {
+                if (newParentId != null && !newParentId.equals(parentId)) {
                     Consumer<E> childConsumer = child -> {
                         //更新了父节点,但是同时也传入的对应的子节点
                         E readyToUpdate = thisTime.get(child.getId());


### PR DESCRIPTION
未传入parentId时，不更新path