### PR TITLE
fix: 优化字典的并行执行

### DIFF
--- a/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/service/TreeSortServiceHelper.java
+++ b/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/service/TreeSortServiceHelper.java
@@ -190,7 +190,7 @@ public class TreeSortServiceHelper<E extends TreeSortSupportEntity<PK>, PK> {
             if (old != null) {
                 PK newParentId = data.getParentId();
                 //父节点发生变化，更新所有子节点path
-                if (!Objects.equals(parentId, newParentId)) {
+                if (newParentId != null && !newParentId.equals(parentId)) {
                     Consumer<E> childConsumer = child -> {
                         //更新了父节点,但是同时也传入的对应的子节点
                         E readyToUpdate = thisTime.get(child.getId());

--- a/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
+++ b/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
@@ -34,10 +34,14 @@ public class DictionaryProperties {
         packages.add("org.hswebframework.web");
         CachingMetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory();
         ResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+        // 获取主线程的类加载器
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         return packages
             .parallelStream()
             .flatMap(enumPackage -> {
+                // 在每个任务中设置一致的类加载器
+                Thread.currentThread().setContextClassLoader(classLoader);
                 String path = "classpath*:" + ClassUtils.convertClassNameToResourcePath(enumPackage) + "/**/*.class";
                 log.info("scan enum dict package:{}", path);
                 Resource[] resources;

--- a/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
+++ b/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
@@ -40,42 +40,44 @@ public class DictionaryProperties {
         Supplier<ClassLoader> classLoaderSupplier = currentThread::getContextClassLoader;
 
         return packages
-            .parallelStream()
-            .flatMap(enumPackage -> {
-                // 在每个任务中设置一致的类加载器
-                ClassLoader prevClassLoader = Thread.currentThread().getContextClassLoader();
-                Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
-                String path = "classpath*:" + ClassUtils.convertClassNameToResourcePath(enumPackage) + "/**/*.class";
-                log.info("scan enum dict package:{}", path);
-                Resource[] resources;
-                try {
-                    resources = resourcePatternResolver.getResources(path);
-                } catch (IOException e) {
-                    log.warn("scan enum dict package:{} error:", path, e);
-                    return Stream.empty();
-                }
-                Stream<? extends Class<?>> stream = Stream
-                    .of(resources)
-                    .map(resource -> {
+                .parallelStream()
+                .flatMap(enumPackage -> {
+                    ClassLoader prevClassLoader = Thread.currentThread().getContextClassLoader();
+                    try {
+                        // 在每个任务中设置一致的类加载器
+                        Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
+                        String path = "classpath*:" + ClassUtils.convertClassNameToResourcePath(enumPackage) + "/**/*.class";
+                        log.info("scan enum dict package:{}", path);
+                        Resource[] resources;
                         try {
-                            // 在每个任务中设置一致的类加载器
-                            Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
-                            MetadataReader reader = metadataReaderFactory.getMetadataReader(resource);
-                            String name = reader.getClassMetadata().getClassName();
-                            Class<?> clazz = ClassUtils.forName(name, classLoaderSupplier.get());
-                            if (clazz.isEnum() && EnumDict.class.isAssignableFrom(clazz)) {
-                                return clazz;
-                            }
-                        } catch (Throwable ignore) {
-
+                            resources = resourcePatternResolver.getResources(path);
+                        } catch (IOException e) {
+                            log.warn("scan enum dict package:{} error:", path, e);
+                            return Stream.empty();
                         }
-                        return null;
-                    })
-                    .filter(Objects::nonNull);
-                // 还原类加载器
-                Thread.currentThread().setContextClassLoader(prevClassLoader);
-                return stream;
-            });
+                        return Stream
+                                .of(resources)
+                                .map(resource -> {
+                                    try {
+                                        // 在每个任务中设置一致的类加载器
+                                        Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
+                                        MetadataReader reader = metadataReaderFactory.getMetadataReader(resource);
+                                        String name = reader.getClassMetadata().getClassName();
+                                        Class<?> clazz = ClassUtils.forName(name, classLoaderSupplier.get());
+                                        if (clazz.isEnum() && EnumDict.class.isAssignableFrom(clazz)) {
+                                            return clazz;
+                                        }
+                                    } catch (Throwable ignore) {
+
+                                    }
+                                    return null;
+                                })
+                                .filter(Objects::nonNull);
+                    } finally {
+                        // 还原类加载器
+                        Thread.currentThread().setContextClassLoader(prevClassLoader);
+                    }
+                });
 
     }
 }

--- a/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
+++ b/hsweb-system/hsweb-system-dictionary/src/main/java/org/hswebframework/web/dictionary/configuration/DictionaryProperties.java
@@ -15,7 +15,6 @@ import org.springframework.util.ClassUtils;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 @ConfigurationProperties(prefix = "hsweb.dict")
@@ -35,49 +34,31 @@ public class DictionaryProperties {
         packages.add("org.hswebframework.web");
         CachingMetadataReaderFactory metadataReaderFactory = new CachingMetadataReaderFactory();
         ResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
-        // 获取主线程的类加载器
-        Thread currentThread = Thread.currentThread();
-        Supplier<ClassLoader> classLoaderSupplier = currentThread::getContextClassLoader;
 
-        return packages
-                .parallelStream()
-                .flatMap(enumPackage -> {
-                    ClassLoader prevClassLoader = Thread.currentThread().getContextClassLoader();
-                    try {
-                        // 在每个任务中设置一致的类加载器
-                        Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
-                        String path = "classpath*:" + ClassUtils.convertClassNameToResourcePath(enumPackage) + "/**/*.class";
-                        log.info("scan enum dict package:{}", path);
-                        Resource[] resources;
-                        try {
-                            resources = resourcePatternResolver.getResources(path);
-                        } catch (IOException e) {
-                            log.warn("scan enum dict package:{} error:", path, e);
-                            return Stream.empty();
-                        }
-                        return Stream
-                                .of(resources)
-                                .map(resource -> {
-                                    try {
-                                        // 在每个任务中设置一致的类加载器
-                                        Thread.currentThread().setContextClassLoader(classLoaderSupplier.get());
-                                        MetadataReader reader = metadataReaderFactory.getMetadataReader(resource);
-                                        String name = reader.getClassMetadata().getClassName();
-                                        Class<?> clazz = ClassUtils.forName(name, classLoaderSupplier.get());
-                                        if (clazz.isEnum() && EnumDict.class.isAssignableFrom(clazz)) {
-                                            return clazz;
-                                        }
-                                    } catch (Throwable ignore) {
-
-                                    }
-                                    return null;
-                                })
-                                .filter(Objects::nonNull);
-                    } finally {
-                        // 还原类加载器
-                        Thread.currentThread().setContextClassLoader(prevClassLoader);
+        List<Class<?>> classes = new ArrayList<>();
+        for (String enumPackage : packages) {
+            String path = "classpath*:" + ClassUtils.convertClassNameToResourcePath(enumPackage) + "/**/*.class";
+            log.info("scan enum dict package:{}", path);
+            Resource[] resources;
+            try {
+                resources = resourcePatternResolver.getResources(path);
+            } catch (IOException e) {
+                log.warn("scan enum dict package:{} error:", path, e);
+                return Stream.empty();
+            }
+            for (Resource resource : resources) {
+                try {
+                    MetadataReader reader = metadataReaderFactory.getMetadataReader(resource);
+                    String name = reader.getClassMetadata().getClassName();
+                    Class<?> clazz = ClassUtils.forName(name, null);
+                    if (clazz.isEnum() && EnumDict.class.isAssignableFrom(clazz)) {
+                        classes.add(clazz);
                     }
-                });
+                } catch (Throwable ignore) {
 
+                }
+            }
+        }
+        return classes.stream();
     }
 }


### PR DESCRIPTION
现象：打包成docker镜像后，缺失字典数据。

原因：初始化时，ClassUtils.forName方法报错ClassNotFound。parallelStream方法是并行的，在springboot3中多个线程的类加载器可能不一致，现已改为统一的类加载器。