### PR TITLE
refactor: 移除 deleteUser 方法中的 readOnly 属性

### DIFF
--- a/hsweb-system/hsweb-system-authorization/hsweb-system-authorization-default/src/main/java/org/hswebframework/web/system/authorization/defaults/service/DefaultReactiveUserService.java
+++ b/hsweb-system/hsweb-system-authorization/hsweb-system-authorization-default/src/main/java/org/hswebframework/web/system/authorization/defaults/service/DefaultReactiveUserService.java
@@ -232,7 +232,7 @@ public class DefaultReactiveUserService extends GenericReactiveCrudService<UserE
     }
 
     @Override
-    @Transactional(readOnly = true, transactionManager = TransactionManagers.reactiveTransactionManager)
+    @Transactional(transactionManager = TransactionManagers.reactiveTransactionManager)
     public Mono<Boolean> deleteUser(String userId) {
         return this
                 .findById(userId)


### PR DESCRIPTION
移除了 DefaultReactiveUserService 类中 deleteUser 方法的 @Transactional 注解的 readOnly 属性。这个属性对于删除操作来说是不必要的，因为删除操作是写操作，而不是只读操作。