### PR TITLE
fix(auth): 修复RedisTokenAuthenticationManager中的令牌删除问题

### DIFF
--- a/hsweb-authorization/hsweb-authorization-api/src/main/java/org/hswebframework/web/authorization/token/redis/RedisTokenAuthenticationManager.java
+++ b/hsweb-authorization/hsweb-authorization-api/src/main/java/org/hswebframework/web/authorization/token/redis/RedisTokenAuthenticationManager.java
@@ -41,7 +41,7 @@ public class RedisTokenAuthenticationManager implements TokenAuthenticationManag
     @Override
     public Mono<Void> removeToken(String token) {
         return operations
-                .delete(token)
+                .delete("token-auth:" + token)
                 .then();
     }
 


### PR DESCRIPTION
- 修改令牌删除逻辑，添加了"token-auth:"前缀以匹配正确的Redis键格式