### PR TITLE
fix(crud): 修复多 CTE 查询重写缺少逗号

### DIFF
--- a/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/query/QueryAnalyzerImpl.java
+++ b/hsweb-commons/hsweb-commons-crud/src/main/java/org/hswebframework/web/crud/query/QueryAnalyzerImpl.java
@@ -878,6 +878,8 @@ class QueryAnalyzerImpl implements FromItemVisitor, SelectItemVisitor, SelectVis
         public void visit(WithItem withItem) {
             if (!StringUtils.hasText(prefix)) {
                 prefix += "WITH ";
+            } else {
+                prefix += ", ";
             }
             prefix += withItem;
             PrepareStatementVisitor visitor = new PrepareStatementVisitor();

--- a/hsweb-commons/hsweb-commons-crud/src/test/java/org/hswebframework/web/crud/query/QueryAnalyzerImplTest.java
+++ b/hsweb-commons/hsweb-commons-crud/src/test/java/org/hswebframework/web/crud/query/QueryAnalyzerImplTest.java
@@ -772,32 +772,14 @@ public class QueryAnalyzerImplTest {
                 "LEFT JOIN cte2 ON cte1.id = cte2.id");
 
         SqlRequest request = analyzer
-            .refactor(QueryParamEntity.of().toQuery().and("name", "like", "test%").getParam(), 1, "test");
+            .refactor(QueryParamEntity.of().toQuery().and("name", "like", "test%").getParam(), "test", "test");
 
         System.out.println(request);
-        
-        // 多个CTE在某些情况下生成的SQL可能无法直接执行（CTE之间缺少逗号），只验证SQL生成
+
         assertNotNull(request.getSql(), "SQL should be generated");
         assertNotNull(request.getParameters(), "Parameters should be set");
-        // 如果生成的SQL语法正确，尝试执行
-        try {
-            executeAndVerify(request);
-        } catch (AssertionError e) {
-            // 如果是语法错误，只验证SQL已生成
-            if (e.getMessage() != null && e.getMessage().contains("Syntax error")) {
-                System.out.println("SQL generated but has syntax issue (CTE comma missing): " + e.getMessage());
-                return;
-            }
-            throw e;
-        } catch (Exception e) {
-            // 如果是语法错误，只验证SQL已生成
-            if (e.getMessage() != null && (e.getMessage().contains("Syntax error") || 
-                                         e.getMessage().contains("expected"))) {
-                System.out.println("SQL generated but has syntax issue (CTE comma missing): " + e.getMessage());
-                return;
-            }
-            throw e;
-        }
+        assertTrue(request.getSql().contains("), cte2 AS"), "multiple CTEs should be separated by comma");
+        executeAndVerify(request);
     }
 
     @Test


### PR DESCRIPTION
## 目的

修复 QueryHelper 执行包含多个 WITH CTE 的原生 SQL 时，SQL 重写结果丢失 CTE 分隔逗号，导致数据库执行失败的问题。

## 核心变动

- crud：在 QueryAnalyzerImpl 重写多个 WithItem 时补充分隔逗号
- crud-test：收紧 testMultipleCTE，断言生成 SQL 包含 CTE 分隔逗号并实际执行验证

## 测试结果

- 命令：`.\mvnw.cmd -pl hsweb-commons/hsweb-commons-crud -Dtest=QueryAnalyzerImplTest test`
- 单元测试：56 passed, 0 failed, 0 errors, 0 skipped
- 覆盖率：line 24.82%, branch 22.76%, instruction 25.49%

## 风险与说明

- 影响范围：QueryHelper 原生 SQL 中 WITH CTE 的 SQL 重写
- 未覆盖场景：未执行全仓测试
- 已知限制：覆盖率数据来自目标测试类运行后的 hsweb-commons-crud 模块 JaCoCo 报告
