### PR TITLE
Add Redis service to 5.0.x GitHub Actions PR workflow

### DIFF
--- a/.github/workflows/pull_request_5x.yml
+++ b/.github/workflows/pull_request_5x.yml
@@ -8,6 +8,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
### Motivation
- Provide a Redis instance for pull request CI runs on the `5.0.x` branch to support tests that require Redis.

### Description
- Add a `redis` service to `.github/workflows/pull_request_5x.yml` using `redis:7-alpine` with port mapping and a health check so the job exposes a healthy Redis during the build.

### Testing
- The workflow is configured to run Maven tests via `./mvnw test -q` as part of the `Build with Maven` step, and no automated test run results are included in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eca108dfe483339010c31ea1af3cfb)