### PR TITLE
fix(bean): 修复FastBeanCopier对CharSequence属性的复制支持

### DIFF
--- a/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
+++ b/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
@@ -587,7 +587,7 @@ public final class FastBeanCopier {
                     return convert(val, targetClass, genericType);
                 }
             }
-            if (targetClass == String.class) {
+            if (targetClass == String.class || targetClass == CharSequence.class) {
                 if (source instanceof Date) {
                     // TODO: 18-4-16 自定义格式
                     return (T) DateFormatter.toString(((Date) source), "yyyy-MM-dd HH:mm:ss");

--- a/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
+++ b/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
@@ -161,6 +161,18 @@ public class FastBeanCopierTest {
 
     }
 
+    @Test
+    public void testCharSequence() {
+        CharSequenceTarget beanTarget = FastBeanCopier.copy(new CharSequenceSource("test"), new CharSequenceTarget());
+        Assert.assertEquals("test", String.valueOf(beanTarget.getValue()));
+
+        Map<String, Object> source = new HashMap<>();
+        source.put("value", 123);
+
+        CharSequenceTarget mapTarget = FastBeanCopier.copy(source, new CharSequenceTarget());
+        Assert.assertEquals("123", String.valueOf(mapTarget.getValue()));
+    }
+
     @Getter
     @Setter
     public static class Config {
@@ -176,6 +188,22 @@ public class FastBeanCopierTest {
         public String toString() {
             return "name:" + name;
         }
+    }
+
+    @Getter
+    @Setter
+    public static class CharSequenceSource {
+        private String value;
+
+        public CharSequenceSource(String value) {
+            this.value = value;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class CharSequenceTarget {
+        private CharSequence value;
     }
 
     @Test

--- a/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
+++ b/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
@@ -163,8 +163,9 @@ public class FastBeanCopierTest {
 
     @Test
     public void testCharSequence() {
-        CharSequenceTarget beanTarget = FastBeanCopier.copy(new CharSequenceSource("test"), new CharSequenceTarget());
-        Assert.assertEquals("test", String.valueOf(beanTarget.getValue()));
+        StringBuilder builder = new StringBuilder("test");
+        CharSequenceTarget beanTarget = FastBeanCopier.copy(new CharSequenceSource(builder), new CharSequenceTarget());
+        Assert.assertSame(builder, beanTarget.getValue());
 
         Map<String, Object> source = new HashMap<>();
         source.put("value", 123);
@@ -193,9 +194,9 @@ public class FastBeanCopierTest {
     @Getter
     @Setter
     public static class CharSequenceSource {
-        private String value;
+        private CharSequence value;
 
-        public CharSequenceSource(String value) {
+        public CharSequenceSource(CharSequence value) {
             this.value = value;
         }
     }


### PR DESCRIPTION
## 目的

- 修复 `FastBeanCopier` 在复制到 `CharSequence` 属性时缺少直接类型转换支持的问题
- 避免 bean -> bean、map -> bean 场景下写入 `CharSequence` 属性失败

## 核心变动

- `hsweb-core`：在 `FastBeanCopier.DefaultConverter` 中将 `CharSequence.class` 纳入与 `String.class` 相同的直接转换分支
- `hsweb-core`：为 `FastBeanCopierTest` 增加 `testCharSequence`
  - 覆盖 `String -> CharSequence`
  - 覆盖 `Map(Number) -> CharSequence`

## 测试结果

- 命令：`export JAVA_HOME=$(/usr/libexec/java_home -v 17) && ./mvnw -pl hsweb-core -Dtest=FastBeanCopierTest test`
- 测试：13 passed, 0 failed, 0 errors, 0 skipped
- 变更逻辑覆盖率（`FastBeanCopier` 本次变更行）：line 100.00% (3/3), branch 100.00% (6/6)

## 风险与说明

- 影响范围：`FastBeanCopier` 对 `CharSequence` 目标属性的默认转换逻辑
- 兼容性：沿用现有 `String.valueOf(source)` 行为，不改变 `String` 分支已有语义
- 未覆盖项：本次仅修复 `FastBeanCopier`，不扩展其他独立类型转换入口
