### PR TITLE
fix: 修复FastBeanCopier父类泛型字段复制

### DIFF
--- a/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
+++ b/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
@@ -402,9 +402,11 @@ public final class FastBeanCopier {
                 Field field = ReflectionUtils.findField(targetBeanType, name);
                 boolean hasGeneric = false;
                 if (field != null) {
-                    String[] arr = Arrays.stream(ResolvableType.forField(field)
-                                                               .getGenerics())
-                                         .map(ResolvableType::getRawClass)
+                    ResolvableType fieldType = ResolvableType.forField(
+                        field,
+                        ResolvableType.forClass(targetBeanType).as(field.getDeclaringClass()));
+                    String[] arr = Arrays.stream(fieldType.getGenerics())
+                                         .map(ResolvableType::resolve)
                                          .filter(Objects::nonNull)
                                          .map(t -> t.getName().concat(".class"))
                                          .toArray(String[]::new);

--- a/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierBeanTest.java
+++ b/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierBeanTest.java
@@ -1,0 +1,63 @@
+package org.hswebframework.web.bean;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class FastBeanCopierBeanTest {
+
+    @Test
+    public void testCopyDirectGenericListField() {
+        Map<String, Object> source = Map.of(
+            "fileData",
+            List.of(Map.of("name", "image.jpg"))
+        );
+
+        DirectOutput output = FastBeanCopier.copy(source, new DirectOutput());
+
+        Assert.assertNotNull(output.getFileData());
+        Assert.assertEquals(1, output.getFileData().size());
+        Assert.assertTrue(output.getFileData().get(0) instanceof FileItem);
+        Assert.assertEquals("image.jpg", output.getFileData().get(0).getName());
+    }
+
+    @Test
+    public void testCopyGenericSuperclassListField() {
+        Map<String, Object> source = Map.of(
+            "fileData",
+            List.of(Map.of("name", "image.jpg"))
+        );
+
+        GenericOutput output = FastBeanCopier.copy(source, new GenericOutput());
+
+        Assert.assertNotNull(output.getFileData());
+        Assert.assertEquals(1, output.getFileData().size());
+        Assert.assertTrue(output.getFileData().get(0) instanceof FileItem);
+        Assert.assertEquals("image.jpg", output.getFileData().get(0).getName());
+    }
+
+    @Getter
+    @Setter
+    public static class DirectOutput {
+        private List<FileItem> fileData;
+    }
+
+    @Getter
+    @Setter
+    public static class GenericBase<T> {
+        private List<T> fileData;
+    }
+
+    public static class GenericOutput extends GenericBase<FileItem> {
+    }
+
+    @Getter
+    @Setter
+    public static class FileItem {
+        private String name;
+    }
+}


### PR DESCRIPTION
## 变更说明
- 修复 FastBeanCopier 解析父类泛型字段时未带入目标子类上下文的问题
- 使用 ResolvableType.resolve() 获取子类绑定后的实际泛型类型
- 新增 FastBeanCopierBeanTest 覆盖直接泛型字段和父类泛型字段复制场景

## 验证
- zsh -lic 'java21; mvn -pl hsweb-core -Dtest=FastBeanCopierBeanTest test'