### PR TITLE
feat(bean): 支持FastBeanCopier复制record

### DIFF
--- a/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
+++ b/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
@@ -21,7 +21,10 @@ import org.springframework.util.ReflectionUtils;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -110,6 +113,9 @@ public final class FastBeanCopier {
 
     @SneakyThrows
     public static <T, S> T copy(S source, Class<T> target, String... ignore) {
+        if (isRecordType(target)) {
+            return copyToRecord(source, target, DEFAULT_CONVERT, ignore);
+        }
         return copy(source, target.newInstance(), DEFAULT_CONVERT, ignore);
     }
 
@@ -123,6 +129,10 @@ public final class FastBeanCopier {
 
     @SuppressWarnings("all")
     public static <T, S> T copy(S source, T target, Converter converter, Set<String> ignore) {
+        if (target != null && isRecordType(getUserClass(target))) {
+            // Java 8 基线不能直接引用 RecordComponent；record 不可变，只能重建新实例。
+            return (T) copyToRecord(source, (Class) getUserClass(target), converter, ignore);
+        }
         if (source instanceof Map && target instanceof Map) {
             if (CollectionUtils.isEmpty(ignore)) {
                 ((Map) target).putAll(((Map) source));
@@ -140,6 +150,52 @@ public final class FastBeanCopier {
         getCopier(source, target, true)
             .copy(source, target, ignore, converter);
         return target;
+    }
+
+    @SneakyThrows
+    static <T, S> T copyToRecord(S source, Class<T> target, Converter converter, String... ignore) {
+        Set<String> ignored = (ignore == null || ignore.length == 0)
+            ? Collections.emptySet()
+            : new HashSet<>(Arrays.asList(ignore));
+        return copyToRecord(source, target, converter, ignored);
+    }
+
+    @SneakyThrows
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static <T, S> T copyToRecord(S source, Class<T> target, Converter converter, Set<String> ignore) {
+        // record 没有无参构造和 setter，只能按 canonical constructor 的组件顺序组装参数。
+        Object[] components = getRecordComponents(target);
+        Class<?>[] constructorTypes = new Class<?>[components.length];
+        Object[] values = new Object[components.length];
+        Map<String, ClassProperty> sourceProperties = source instanceof Map
+            ? Collections.emptyMap()
+            : createProperty(getUserClass(source));
+
+        for (int i = 0; i < components.length; i++) {
+            Object component = components[i];
+            String name = getRecordComponentName(component);
+            Class<?> componentType = getRecordComponentType(component);
+            constructorTypes[i] = componentType;
+            if (ignore != null && ignore.contains(name)) {
+                values[i] = defaultValue(componentType);
+                continue;
+            }
+            Object value = readRecordSourceValue(source, sourceProperties, name);
+            if (value != null) {
+                Class[] genericTypes = resolveRecordGenericTypes(component);
+                boolean requiresGenericConversion = genericTypes.length > 0
+                    && (Collection.class.isAssignableFrom(componentType) || Map.class.isAssignableFrom(componentType));
+                if (requiresGenericConversion || !isDirectAssignable(componentType, value)) {
+                    value = converter.convert(value, (Class) componentType, genericTypes);
+                }
+            }
+            values[i] = value == null && componentType.isPrimitive()
+                ? defaultValue(componentType)
+                : value;
+        }
+        Constructor<T> constructor = target.getDeclaredConstructor(constructorTypes);
+        ReflectionUtils.makeAccessible(constructor);
+        return constructor.newInstance(values);
     }
 
     static Class<?> getUserClass(Object object) {
@@ -218,6 +274,10 @@ public final class FastBeanCopier {
 
     private static Map<String, ClassProperty> createProperty(Class<?> type) {
 
+        if (isRecordType(type)) {
+            return createRecordProperty(type);
+        }
+
         List<String> fieldNames = Arrays
             .stream(type.getDeclaredFields())
             .map(Field::getName)
@@ -232,6 +292,15 @@ public final class FastBeanCopier {
                      .sorted(Comparator.comparing(property -> fieldNames.indexOf(property.name)))
                      .collect(Collectors.toMap(ClassProperty::getName, Function.identity(), (k, k2) -> k, LinkedHashMap::new));
 
+    }
+
+    private static Map<String, ClassProperty> createRecordProperty(Class<?> type) {
+        return Arrays.stream(getRecordComponents(type))
+                     .map(RecordClassProperty::new)
+                     .collect(Collectors.toMap(ClassProperty::getName,
+                                               Function.identity(),
+                                               (k, k2) -> k,
+                                               LinkedHashMap::new));
     }
 
     private static Map<String, ClassProperty> createMapProperty(Map<String, ClassProperty> template) {
@@ -517,6 +586,22 @@ public final class FastBeanCopier {
         }
     }
 
+    static class RecordClassProperty extends ClassProperty {
+        public RecordClassProperty(Object component) {
+            type = getRecordComponentType(component);
+            Method accessor = getRecordComponentAccessor(component);
+            readMethodName = accessor.getName();
+            writeMethodName = null;
+
+            getter = createGetterFunction();
+            setter = createSetterFunction(paramGetter -> {
+                throw new UnsupportedOperationException("Record property is read-only: " + getRecordComponentName(component));
+            });
+            name = getRecordComponentName(component);
+            beanType = accessor.getDeclaringClass();
+        }
+    }
+
     static class MapClassProperty extends ClassProperty {
         public MapClassProperty(String name) {
             type = Object.class;
@@ -540,6 +625,116 @@ public final class FastBeanCopier {
         }
     }
 
+
+    static boolean isRecordType(Class<?> type) {
+        try {
+            Method method = Class.class.getMethod("isRecord");
+            return Boolean.TRUE.equals(method.invoke(type));
+        } catch (Throwable ignore) {
+            return false;
+        }
+    }
+
+    static Object[] getRecordComponents(Class<?> type) {
+        try {
+            Method method = Class.class.getMethod("getRecordComponents");
+            Object components = method.invoke(type);
+            return components == null ? new Object[0] : (Object[]) components;
+        } catch (Throwable e) {
+            throw new UnsupportedOperationException("Unsupported record type: " + type, e);
+        }
+    }
+
+    static String getRecordComponentName(Object component) {
+        return invokeRecordComponentMethod(component, "getName", String.class);
+    }
+
+    static Class<?> getRecordComponentType(Object component) {
+        return invokeRecordComponentMethod(component, "getType", Class.class);
+    }
+
+    static Method getRecordComponentAccessor(Object component) {
+        return invokeRecordComponentMethod(component, "getAccessor", Method.class);
+    }
+
+    static Type getRecordComponentGenericType(Object component) {
+        return invokeRecordComponentMethod(component, "getGenericType", Type.class);
+    }
+
+    @SneakyThrows
+    private static <T> T invokeRecordComponentMethod(Object component, String methodName, Class<T> returnType) {
+        Method method = component.getClass().getMethod(methodName);
+        return returnType.cast(method.invoke(component));
+    }
+
+    private static Object readRecordSourceValue(Object source, Map<String, ClassProperty> sourceProperties, String name) throws Exception {
+        if (source instanceof Map) {
+            return ((Map<?, ?>) source).get(name);
+        }
+        ClassProperty property = sourceProperties.get(name);
+        if (property == null) {
+            return null;
+        }
+        Method method = ReflectionUtils.findMethod(property.getBeanType(), property.getReadMethodName());
+        if (method == null) {
+            return null;
+        }
+        ReflectionUtils.makeAccessible(method);
+        return method.invoke(source);
+    }
+
+    private static Class<?>[] resolveRecordGenericTypes(Object component) {
+        Class<?>[] genericTypes = Arrays.stream(ResolvableType.forType(getRecordComponentGenericType(component)).getGenerics())
+                                        .map(ResolvableType::getRawClass)
+                                        .filter(Objects::nonNull)
+                                        .toArray(Class[]::new);
+        return genericTypes.length == 0 ? EMPTY_CLASS_ARRAY : genericTypes;
+    }
+
+    private static boolean isDirectAssignable(Class<?> targetType, Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (targetType.isInstance(value)) {
+            return true;
+        }
+        if (!targetType.isPrimitive()) {
+            return false;
+        }
+        Class<?> wrapper = wrapperClassMapping.get(targetType);
+        return wrapper != null && wrapper.isInstance(value);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return (char) 0;
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        return null;
+    }
 
     public static final class DefaultConverter implements Converter {
         private BeanFactory beanFactory = BEAN_FACTORY;
@@ -721,6 +916,9 @@ public final class FastBeanCopier {
                     return (T) copy(source, Maps.newHashMapWithExpectedSize(sourType.getFieldSize()));
                 }
 
+                if (isRecordType(targetClass)) {
+                    return copyToRecord(source, targetClass, this, Collections.emptySet());
+                }
                 return copy(source, beanFactory.newInstance(targetClass), this);
             } catch (Exception e) {
                 log.warn("复制类型{}->{}失败", targetClass, e);

--- a/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
+++ b/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import org.hswebframework.ezorm.core.DefaultExtendable;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.springframework.util.ClassUtils;
 
@@ -15,7 +16,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.*;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -174,6 +179,105 @@ public class FastBeanCopierTest {
         public String toString() {
             return "name:" + name;
         }
+    }
+
+    @Test
+    @SneakyThrows
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testRecordCopy() {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        Assume.assumeNotNull(compiler);
+
+        File sourceDir = new File("target/generated-test-records/src/org/hswebframework/web/bean/recordcopy");
+        File classesDir = new File("target/generated-test-records/classes");
+        sourceDir.mkdirs();
+        classesDir.mkdirs();
+
+        File nestedFile = writeRecordSource(sourceDir,
+                                            "NestedRecord.java",
+                                            "package org.hswebframework.web.bean.recordcopy;\n" +
+                                                "public record NestedRecord(String name) { }\n");
+        File sourceFile = writeRecordSource(sourceDir,
+                                            "SourceRecord.java",
+                                            "package org.hswebframework.web.bean.recordcopy;\n" +
+                                                "import org.hswebframework.web.bean.Color;\n" +
+                                                "public record SourceRecord(String name, int age, Color color2, NestedRecord nested) { }\n");
+        File targetFile = writeRecordSource(sourceDir,
+                                            "TargetRecord.java",
+                                            "package org.hswebframework.web.bean.recordcopy;\n" +
+                                                "import java.util.List;\n" +
+                                                "import org.hswebframework.web.bean.Color;\n" +
+                                                "public record TargetRecord(String name, int age, Color color2, NestedRecord nested, List<NestedRecord> nestedList) { }\n");
+
+        int exit = compiler.run(null,
+                                null,
+                                null,
+                                "--release",
+                                "17",
+                                "-classpath",
+                                System.getProperty("java.class.path"),
+                                "-d",
+                                classesDir.getAbsolutePath(),
+                                nestedFile.getAbsolutePath(),
+                                sourceFile.getAbsolutePath(),
+                                targetFile.getAbsolutePath());
+        Assume.assumeTrue("Current JDK does not support compiling record test classes", exit == 0);
+
+        try (URLClassLoader loader = new URLClassLoader(new URL[]{classesDir.toURI().toURL()},
+                                                        ClassUtils.getDefaultClassLoader())) {
+            Class<?> nestedClass = loader.loadClass("org.hswebframework.web.bean.recordcopy.NestedRecord");
+            Class<?> sourceClass = loader.loadClass("org.hswebframework.web.bean.recordcopy.SourceRecord");
+            Class<?> targetClass = loader.loadClass("org.hswebframework.web.bean.recordcopy.TargetRecord");
+
+            Map<String, Object> values = new LinkedHashMap<>();
+            values.put("name", "record-target");
+            values.put("age", "18");
+            values.put("color2", "RED");
+            values.put("nested", Collections.singletonMap("name", "nested-map"));
+            values.put("nestedList", Collections.singletonList(Collections.singletonMap("name", "nested-list")));
+
+            Object target = FastBeanCopier.copy(values, (Class) targetClass);
+            Assert.assertEquals("record-target", invokeAccessor(target, "name"));
+            Assert.assertEquals(18, invokeAccessor(target, "age"));
+            Assert.assertEquals(Color.RED, invokeAccessor(target, "color2"));
+            Assert.assertEquals("nested-map", invokeAccessor(invokeAccessor(target, "nested"), "name"));
+            List<?> nestedList = (List<?>) invokeAccessor(target, "nestedList");
+            Assert.assertEquals("nested-list", invokeAccessor(nestedList.get(0), "name"));
+
+            Object ignored = FastBeanCopier.copy(values, (Class) targetClass, "age");
+            Assert.assertEquals(0, invokeAccessor(ignored, "age"));
+
+            Object nested = nestedClass.getDeclaredConstructor(String.class).newInstance("nested-source");
+            Object source = sourceClass
+                .getDeclaredConstructor(String.class, int.class, Color.class, nestedClass)
+                .newInstance("record-source", 20, Color.BLUE, nested);
+
+            Target beanTarget = FastBeanCopier.copy(source, new Target());
+            Assert.assertEquals("record-source", beanTarget.getName());
+            Assert.assertEquals(20, beanTarget.getAge());
+            Assert.assertEquals(Color.BLUE, beanTarget.getColor2());
+
+            Map<String, Object> copiedMap = FastBeanCopier.copy(source, new HashMap<>());
+            Assert.assertEquals("record-source", copiedMap.get("name"));
+            Assert.assertEquals(20, copiedMap.get("age"));
+
+            Object emptyTarget = targetClass
+                .getDeclaredConstructor(String.class, int.class, Color.class, nestedClass, List.class)
+                .newInstance("old", 1, Color.BLUE, nested, Collections.emptyList());
+            Object rebuilt = FastBeanCopier.copy(values, emptyTarget);
+            Assert.assertNotSame(emptyTarget, rebuilt);
+            Assert.assertEquals("record-target", invokeAccessor(rebuilt, "name"));
+        }
+    }
+
+    private File writeRecordSource(File sourceDir, String fileName, String source) throws IOException {
+        File file = new File(sourceDir, fileName);
+        Files.write(file.toPath(), source.getBytes(StandardCharsets.UTF_8));
+        return file;
+    }
+
+    private Object invokeAccessor(Object target, String name) throws Exception {
+        return target.getClass().getMethod(name).invoke(target);
     }
 
     @Test


### PR DESCRIPTION
## 目的

- 为 `master` 基准分支补齐 FastBeanCopier 对 Java `record` 的复制支持。
- 解决 record 无无参构造和 setter 时，`FastBeanCopier.copy(source, TargetRecord.class)` 无法构造目标对象的问题。
- 保持 `master` 的 Java 8 源码基线，不直接引用 Java 16+ 的 `RecordComponent` 类型。

## 核心变动

- `hsweb-core`：
  - 通过反射探测 `Class#isRecord` 与 `Class#getRecordComponents`，避免破坏 Java 8 编译基线。
  - 新增 record 构造路径：按 record component 顺序读取源值并调用 canonical constructor。
  - 支持 `Map -> record`、`bean/record -> record`、`record -> bean`、`record -> Map`。
  - 支持 nested record、`List<Record>` 泛型集合、primitive 默认值与 ignore 字段。
  - 当已有 record 实例作为 target 时，由于 record 不可变，会重新构造并返回新实例。
- 测试：
  - 在 Java 8 测试源码中通过 `JavaCompiler` 动态编译 record 测试类，验证运行时 record 支持。

## 设计与测试目标

- 设计稿：不适用；本次为 hsweb-core 基础工具能力增强，范围集中在 FastBeanCopier。
- 用户确认：已确认需要在 `master` 基准分支单独支持 record。
- 测试目标：覆盖 record 正常复制、嵌套 record、泛型集合转换、ignore 字段、既有 FastBeanCopier 回归路径。
- 注释 / 公共契约：已在 record 构造入口补充 Java 8 基线和 record 不可变说明；未新增 SPI。
- 数据权限：不适用；不涉及 CRUD / AssetsHolder。
- 数据库兼容与性能：不适用；不涉及 SQL。
- 链路追踪：不适用；本次为通用 bean copy 工具，不涉及关键业务链路。
- MBean 运维可观测性：不适用；未新增常驻任务、队列或后台执行器。

## 测试结果

- 命令：`mvn -pl hsweb-core -Dtest=FastBeanCopierTest -Djacoco.skip=true test`
- 新增/更新测试：`FastBeanCopierTest#testRecordCopy` 覆盖 Map/bean/record 与 nested record 复制路径。
- 单元测试：`12 passed, 0 failed, 0 skipped`
- 集成测试：不适用；未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配。
- 压力测试：不适用；record 支持为构造路径补齐，本次未新增性能压测要求。
- 覆盖率：
  - 使用 JaCoCo 0.8.8 在当前 JDK 运行会输出 `Unsupported class file major version 65` 的插桩告警。
  - focused record 用例生成的报告中：hsweb-core overall line `15.33%`, branch `11.82%`；`FastBeanCopier` line `69.53%`, branch `50.68%`。
  - 完整 `FastBeanCopierTest` 为避免 JaCoCo/JDK 版本告警，使用 `-Djacoco.skip=true` 验证通过。

## 文档同步情况

- 已同步：无长期文档需要同步。
- 未同步：README 未修改；FastBeanCopier 对外用法无长期总览变更。
- 说明：测试证据放在 PR / CI，未新增独立任务流水文档。

## 风险与说明

- 影响范围：`hsweb-core` 的 FastBeanCopier 复制和转换路径。
- 注释 / 公共契约：已补 Java 8 基线与 record 不可变说明；未新增 SPI / public contract 破坏性变更。
- 链路追踪 / 可观测性：不涉及；本次为基础工具能力增强。
- MBean / 运维可观测性：不涉及；未新增常驻运维对象。
- 未覆盖场景：JDK 8 运行时没有 record API，相关路径会自然不命中；record 测试在不支持 record 编译的 JDK 上会跳过。
- 已知限制：master 为 Java 8 源码基线，record 支持通过反射实现，后续若升级基线可再改为类型安全实现。
