### PR TITLE
feat(bean): 支持FastBeanCopier复制record

### DIFF
--- a/.github/workflows/pull_request_5x.yml
+++ b/.github/workflows/pull_request_5x.yml
@@ -8,9 +8,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
@@ -20,5 +21,5 @@ jobs:
       with:
         path: ~/.m2
         key: ${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-    - name: Build with Maven
-      run: ./mvnw test -q
+    - name: Build changed modules with Maven
+      run: ./mvnw test -q -pl "$(./changes.sh)"

--- a/changes.sh
+++ b/changes.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
 
-# 收集变更模块
-modules=$(git diff --name-only HEAD~1 HEAD | \
-while read file; do
+set -euo pipefail
+
+# 收集变更模块。
+# PR 场景按目标分支对比，避免 CI 修复类提交只修改 .github 时退化为全仓库测试；
+# push 场景保持原有 HEAD~1..HEAD 行为，兼容发布工作流。
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  git fetch origin "${GITHUB_BASE_REF}" --depth=1 >/dev/null 2>&1 || true
+  if git rev-parse --verify "origin/${GITHUB_BASE_REF}" >/dev/null 2>&1; then
+    diff_args=("origin/${GITHUB_BASE_REF}...HEAD")
+  else
+    diff_args=("HEAD~1" "HEAD")
+  fi
+else
+  diff_args=("HEAD~1" "HEAD")
+fi
+
+modules=$(git diff --name-only "${diff_args[@]}" | while read -r file; do
   dir=$(dirname "$file")
   while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
     if [ -f "$dir/pom.xml" ]; then echo "$dir"; break; fi
     dir=$(dirname "$dir")
   done
-done | sort -u | tr '\n' ',' | sed 's/,$//')
+done | sort -u | paste -sd, -)
 
 # 如果为空，则使用默认值 '.'
 if [ -z "$modules" ]; then

--- a/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
+++ b/hsweb-core/src/main/java/org/hswebframework/web/bean/FastBeanCopier.java
@@ -23,6 +23,7 @@ import org.springframework.util.ReflectionUtils;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -39,6 +40,8 @@ import java.util.stream.Stream;
 @Slf4j
 public final class FastBeanCopier {
     private static final Map<CacheKey, Copier> CACHE = new ConcurrentHashMap<>();
+
+    private static final Map<CacheKey, RecordCopier> RECORD_CACHE = new ConcurrentHashMap<>();
 
     private static final PropertyUtilsBean propertyUtils = BeanUtilsBean.getInstance().getPropertyUtils();
 
@@ -112,6 +115,9 @@ public final class FastBeanCopier {
 
     @SneakyThrows
     public static <T, S> T copy(S source, Class<T> target, String... ignore) {
+        if (target.isRecord()) {
+            return copyToRecord(source, target, DEFAULT_CONVERT, ignore);
+        }
         return copy(source, target.newInstance(), DEFAULT_CONVERT, ignore);
     }
 
@@ -125,6 +131,10 @@ public final class FastBeanCopier {
 
     @SuppressWarnings("all")
     public static <T, S> T copy(S source, T target, Converter converter, Set<String> ignore) {
+        if (target != null && getUserClass(target).isRecord()) {
+            // record 不可变，无法写入已存在实例；这里按组件名重新构造并返回新实例。
+            return (T) copyToRecord(source, (Class) getUserClass(target), converter, ignore);
+        }
         if (source instanceof Map && target instanceof Map) {
             if (CollectionUtils.isEmpty(ignore)) {
                 ((Map) target).putAll(((Map) source));
@@ -142,6 +152,45 @@ public final class FastBeanCopier {
         getCopier(source, target, true)
             .copy(source, target, ignore, converter);
         return target;
+    }
+
+    static <T, S> T copyToRecord(S source, Class<T> target, Converter converter, String... ignore) {
+        Set<String> ignored = (ignore == null || ignore.length == 0)
+            ? Collections.emptySet()
+            : new HashSet<>(Arrays.asList(ignore));
+        return copyToRecord(source, target, converter, ignored);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T, S> T copyToRecord(S source, Class<T> target, Converter converter, Set<String> ignore) {
+        return (T) getRecordCopier(getUserClass(source), target)
+            .copy(source, ignore == null ? Collections.emptySet() : ignore, converter);
+    }
+
+    private static RecordCopier getRecordCopier(Class<?> source, Class<?> target) {
+        CacheKey key = createCacheKey(source, target);
+        return RECORD_CACHE.computeIfAbsent(key, k -> createRecordCopier(k.sourceType, k.targetType));
+    }
+
+    private static RecordCopier createRecordCopier(Class<?> source, Class<?> target) {
+        String method = "public Object copy(Object s, java.util.Set ignore, " +
+            "org.hswebframework.web.bean.Converter converter){\n" +
+            "try{\n\t" +
+            createRecordCopierCode(source, target) +
+            "}catch(Throwable e){\n" +
+            "\tthrow new UnsupportedOperationException(e.getMessage(), e);" +
+            "\n}\n" +
+            "\n}";
+        try {
+            @SuppressWarnings("all")
+            Proxy<RecordCopier> proxy = Proxy
+                .create(RecordCopier.class, new Class[]{source, target})
+                .addMethod(method);
+            return proxy.newInstance();
+        } catch (Exception e) {
+            log.error("创建record copy代理对象失败:\n{}", method, e);
+            throw new UnsupportedOperationException(e.getMessage(), e);
+        }
     }
 
     static Class<?> getUserClass(Object object) {
@@ -220,6 +269,10 @@ public final class FastBeanCopier {
 
     private static Map<String, ClassProperty> createProperty(Class<?> type) {
 
+        if (type.isRecord()) {
+            return createRecordProperty(type);
+        }
+
         List<String> fieldNames = Arrays
             .stream(type.getDeclaredFields())
             .map(Field::getName)
@@ -236,12 +289,84 @@ public final class FastBeanCopier {
 
     }
 
+    private static Map<String, ClassProperty> createRecordProperty(Class<?> type) {
+        return Arrays.stream(type.getRecordComponents())
+                     .map(RecordClassProperty::new)
+                     .collect(Collectors.toMap(ClassProperty::getName,
+                                               Function.identity(),
+                                               (k, k2) -> k,
+                                               LinkedHashMap::new));
+    }
+
     private static Map<String, ClassProperty> createMapProperty(Map<String, ClassProperty> template) {
         return template
             .values()
             .stream()
             .map(classProperty -> new MapClassProperty(classProperty.name))
             .collect(Collectors.toMap(ClassProperty::getName, Function.identity(), (k, k2) -> k, LinkedHashMap::new));
+    }
+
+    private static String createRecordCopierCode(Class<?> source, Class<?> target) {
+        Map<String, ClassProperty> sourceProperties = Map.class.isAssignableFrom(source)
+            ? createMapProperty(createRecordProperty(target))
+            : createProperty(source);
+        String sourceTypeName = getTypeName(source);
+        String targetTypeName = getTypeName(target);
+        boolean sourceIsMap = Map.class.isAssignableFrom(source);
+        StringBuilder code = new StringBuilder();
+        code.append(sourceTypeName).append(" $$__source=(").append(sourceTypeName).append(")s;\n\t");
+
+        RecordComponent[] components = target.getRecordComponents();
+        List<String> constructorArgs = new ArrayList<>(components.length);
+        for (RecordComponent component : components) {
+            String name = component.getName();
+            Class<?> type = component.getType();
+            String typeName = getTypeName(type);
+            String varName = "$$__" + name;
+            code.append(typeName).append(" ").append(varName).append("=").append(defaultValueCode(type)).append(";\n\t");
+            code.append("if(!ignore.contains(\"").append(name).append("\")){\n\t\t");
+
+            ClassProperty sourceProperty = sourceProperties.get(name);
+            if (sourceProperty == null) {
+                code.append("// source property not found, keep default value.\n\t");
+                code.append("}\n\t");
+                constructorArgs.add(varName);
+                continue;
+            }
+
+            String valueExpression = sourceIsMap
+                ? "$$__source.get(\"" + name + "\")"
+                : "$$__source." + sourceProperty.getReadMethod();
+            if (sourceProperty.isPrimitive()) {
+                valueExpression = wrapperClassMapping
+                    .get(sourceProperty.getType())
+                    .getName() + ".valueOf(" + valueExpression + ")";
+            }
+            String generic = resolveRecordGenericCode(component);
+            code.append("Object $$__value=(Object)(").append(valueExpression).append(");\n\t\t");
+            code.append("if($$__value!=null){\n\t\t\t");
+            if (requiresRecordGenericConversion(component, type)) {
+                code.append(varName).append("=").append(convertValueCode(type, generic)).append(";\n\t\t");
+            } else {
+                code.append("if(").append(directAssignableCode(type, "$$__value")).append("){\n\t\t\t");
+                code.append(varName).append("=").append(castValueCode(type, "$$__value")).append(";\n\t\t\t");
+                code.append("}else{\n\t\t\t");
+                code.append(varName).append("=").append(convertValueCode(type, generic)).append(";\n\t\t\t");
+                code.append("}\n\t\t");
+            }
+            code.append("}\n\t");
+            code.append("}\n\t");
+            constructorArgs.add(varName);
+        }
+        code.append("return new ").append(targetTypeName).append("(")
+            .append(String.join(",", constructorArgs))
+            .append(");\n");
+        return code.toString();
+    }
+
+    private static boolean requiresRecordGenericConversion(RecordComponent component, Class<?> type) {
+        return ResolvableType.forType(component.getGenericType()).hasGenerics()
+            && (Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type));
     }
 
     private static String createCopierCode(Class<?> source, Class<?> target) {
@@ -521,6 +646,21 @@ public final class FastBeanCopier {
         }
     }
 
+    static class RecordClassProperty extends ClassProperty {
+        public RecordClassProperty(RecordComponent component) {
+            type = component.getType();
+            readMethodName = component.getAccessor().getName();
+            writeMethodName = null;
+
+            getter = createGetterFunction();
+            setter = createSetterFunction(paramGetter -> {
+                throw new UnsupportedOperationException("Record property is read-only: " + component.getName());
+            });
+            name = component.getName();
+            beanType = component.getDeclaringRecord();
+        }
+    }
+
     static class MapClassProperty extends ClassProperty {
         public MapClassProperty(String name) {
             type = Object.class;
@@ -544,6 +684,78 @@ public final class FastBeanCopier {
         }
     }
 
+
+    private static String resolveRecordGenericCode(RecordComponent component) {
+        Class<?>[] genericTypes = Arrays.stream(ResolvableType.forType(component.getGenericType()).getGenerics())
+                                        .map(ResolvableType::getRawClass)
+                                        .filter(Objects::nonNull)
+                                        .toArray(Class[]::new);
+        if (genericTypes.length == 0) {
+            return "org.hswebframework.web.bean.FastBeanCopier.EMPTY_CLASS_ARRAY";
+        }
+        return "new Class[]{" + Arrays.stream(genericTypes)
+                                      .map(type -> getTypeName(type) + ".class")
+                                      .collect(Collectors.joining(",")) + "}";
+    }
+
+    private static String getTypeName(Class<?> type) {
+        if (type.isArray()) {
+            return getTypeName(type.getComponentType()) + "[]";
+        }
+        return type.getName();
+    }
+
+    private static String defaultValueCode(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return "null";
+        }
+        if (type == boolean.class) {
+            return "false";
+        }
+        if (type == char.class) {
+            return "(char)0";
+        }
+        if (type == byte.class) {
+            return "(byte)0";
+        }
+        if (type == short.class) {
+            return "(short)0";
+        }
+        if (type == long.class) {
+            return "0L";
+        }
+        if (type == float.class) {
+            return "0F";
+        }
+        if (type == double.class) {
+            return "0D";
+        }
+        return "0";
+    }
+
+    private static String castValueCode(Class<?> type, String value) {
+        if (!type.isPrimitive()) {
+            return "(" + getTypeName(type) + ")" + value;
+        }
+        Class<?> wrapper = wrapperClassMapping.get(type);
+        return "((" + wrapper.getName() + ")" + value + ")." + type.getName() + "Value()";
+    }
+
+    private static String convertValueCode(Class<?> type, String generic) {
+        String converted = "converter.convert($$__value," + getTypeName(type) + ".class," + generic + ")";
+        if (!type.isPrimitive()) {
+            return "(" + getTypeName(type) + ")" + converted;
+        }
+        Class<?> wrapper = wrapperClassMapping.get(type);
+        return "((" + wrapper.getName() + ")" + converted + ")." + type.getName() + "Value()";
+    }
+
+    private static String directAssignableCode(Class<?> type, String value) {
+        Class<?> directType = type.isPrimitive()
+            ? wrapperClassMapping.get(type)
+            : type;
+        return value + " instanceof " + getTypeName(directType);
+    }
 
     public static final class DefaultConverter implements Converter {
         private BeanFactory beanFactory = BEAN_FACTORY;
@@ -696,6 +908,9 @@ public final class FastBeanCopier {
                 if (source instanceof Date) {
                     source = ((Date) source).getTime();
                 }
+            }
+            if (targetClass.isRecord()) {
+                return copyToRecord(source, targetClass, this, Collections.emptySet());
             }
             try {
                 org.apache.commons.beanutils.Converter converter = convertUtils.lookup(targetClass);

--- a/hsweb-core/src/main/java/org/hswebframework/web/bean/RecordCopier.java
+++ b/hsweb-core/src/main/java/org/hswebframework/web/bean/RecordCopier.java
@@ -1,0 +1,25 @@
+package org.hswebframework.web.bean;
+
+import java.util.Set;
+
+/**
+ * Record constructor copier.
+ * <p>
+ * Record is immutable and cannot reuse {@link Copier}'s in-place target mutation contract,
+ * so generated implementations return a newly constructed record instance.
+ *
+ * @author zhouhao
+ * @since 5.0.2
+ */
+public interface RecordCopier {
+
+    /**
+     * Copy source values into a new record instance by canonical constructor order.
+     *
+     * @param source source bean, record or map; generated implementations cast it to the cached source type
+     * @param ignore record component names to keep at Java default values
+     * @param converter value converter used when source and target component types are not directly assignable
+     * @return new record instance; never mutates an existing target record
+     */
+    Object copy(Object source, Set<String> ignore, Converter converter);
+}

--- a/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
+++ b/hsweb-core/src/test/java/org/hswebframework/web/bean/FastBeanCopierTest.java
@@ -208,6 +208,80 @@ public class FastBeanCopierTest {
     }
 
     @Test
+    public void testRecordCopy() {
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("name", "record-target");
+        values.put("age", "18");
+        values.put("color2", "RED");
+        values.put("nested", Collections.singletonMap("name", "nested-map"));
+        values.put("nestedList", Collections.singletonList(Collections.singletonMap("name", "nested-list")));
+
+        TargetRecord target = FastBeanCopier.copy(values, TargetRecord.class);
+
+        Assert.assertEquals("record-target", target.name());
+        Assert.assertEquals(18, target.age());
+        Assert.assertEquals(Color.RED, target.color2());
+        Assert.assertEquals("nested-map", target.nested().name());
+        Assert.assertEquals("nested-list", target.nestedList().get(0).name());
+
+        SourceRecord source = new SourceRecord("record-source", 20, Color.BLUE, new NestedRecord("nested-source"));
+        Target beanTarget = FastBeanCopier.copy(source, new Target());
+        Assert.assertEquals("record-source", beanTarget.getName());
+        Assert.assertEquals(20, beanTarget.getAge());
+        Assert.assertEquals(Color.BLUE, beanTarget.getColor2());
+
+        Map<String, Object> copiedMap = FastBeanCopier.copy(source, new HashMap<>());
+        Assert.assertEquals("record-source", copiedMap.get("name"));
+        Assert.assertEquals(20, copiedMap.get("age"));
+
+        TargetRecord ignored = FastBeanCopier.copy(values, TargetRecord.class, "age");
+        Assert.assertEquals(0, ignored.age());
+
+        TargetRecord ignoredNested = FastBeanCopier.copy(values, TargetRecord.class, "nested");
+        Assert.assertNull(ignoredNested.nested());
+
+        TargetRecord rebuilt = FastBeanCopier.copy(values, new TargetRecord("old", 1, Color.BLUE, null, Collections.emptyList()));
+        Assert.assertEquals("record-target", rebuilt.name());
+
+        Source beanSource = new Source();
+        beanSource.setName("bean-source");
+        beanSource.setAge(19);
+        beanSource.setColor2("蓝色");
+        BeanRecord beanRecord = FastBeanCopier.copy(beanSource, BeanRecord.class);
+        Assert.assertEquals("bean-source", beanRecord.name());
+        Assert.assertEquals(19, beanRecord.age());
+        Assert.assertEquals(Color.BLUE, beanRecord.color2());
+
+        TargetRecord recordTarget = FastBeanCopier.copy(source, TargetRecord.class);
+        Assert.assertEquals("record-source", recordTarget.name());
+        Assert.assertEquals(20, recordTarget.age());
+        Assert.assertEquals(Color.BLUE, recordTarget.color2());
+        Assert.assertEquals("nested-source", recordTarget.nested().name());
+        Assert.assertNull(recordTarget.nestedList());
+
+        Map<String, Object> partialValues = new LinkedHashMap<>();
+        partialValues.put("name", "partial-record");
+        partialValues.put("nested", new NestedRecord("direct-nested"));
+        TargetRecord partial = FastBeanCopier.copy(partialValues, TargetRecord.class);
+        Assert.assertEquals("partial-record", partial.name());
+        Assert.assertEquals(0, partial.age());
+        Assert.assertNull(partial.color2());
+        Assert.assertEquals("direct-nested", partial.nested().name());
+    }
+
+    public record SourceRecord(String name, int age, Color color2, NestedRecord nested) {
+    }
+
+    public record TargetRecord(String name, int age, Color color2, NestedRecord nested, List<NestedRecord> nestedList) {
+    }
+
+    public record BeanRecord(String name, int age, Color color2) {
+    }
+
+    public record NestedRecord(String name) {
+    }
+
+    @Test
     public void testCopyMap() {
 
 


### PR DESCRIPTION
## 目的

- 为 `5.0.x` 基准分支补齐 FastBeanCopier 对 Java `record` 的复制支持。
- 解决 record 无无参构造和 setter 时，`FastBeanCopier.copy(source, TargetRecord.class)` 无法构造目标对象的问题。
- 将 record 目标复制从普通 bean 原地写入契约中拆出，避免每次 copy 走 `Constructor#newInstance` 反射构造。

## 核心变动

- `hsweb-core`：
  - 新增 `RecordCopier`，单独承载 record canonical constructor 复制契约，返回新 record 实例。
  - 基于现有 `Proxy` 机制生成 `RecordCopier` 实现，并通过 `RECORD_CACHE` 按 source/target 类型缓存。
  - 生成代码直接读取 `Map` / bean / record 源属性，按 record component 顺序调用 canonical constructor。
  - 支持 `Map -> record`、`bean -> record`、`record -> record`、`record -> bean`、`record -> Map`。
  - 支持 nested record、`List<Record>` 泛型集合、primitive 默认值、非 primitive ignore 默认 `null`、直接可赋值组件复用。
  - 当已有 record 实例作为 target 时，由于 record 不可变，会重新构造并返回新实例。
- 测试：
  - 扩展 `FastBeanCopierTest#testRecordCopy`，覆盖 Map/bean/record 与 nested record、集合泛型、ignore、缺省值等复制路径。

## 设计与测试目标

- 设计稿：不适用；本次为 hsweb-core 基础工具能力增强，范围集中在 FastBeanCopier。
- 用户确认：已确认需要基于 `5.0.x` 单独支持 record，并优先采用非每次 copy 反射构造方案。
- 测试目标：覆盖 record 正常复制、嵌套 record、泛型集合转换、ignore 字段、缺省值、既有 FastBeanCopier 回归路径。
- 注释 / 公共契约：已为 `RecordCopier` 补充接口与方法契约说明；FastBeanCopier 中保留 record 不可变重建说明。
- 数据权限：不适用；不涉及 CRUD / AssetsHolder。
- 数据库兼容与性能：不适用；不涉及 SQL。
- 链路追踪：不适用；本次为通用 bean copy 工具，不涉及关键业务链路。
- MBean 运维可观测性：不适用；未新增常驻任务、队列或后台执行器。

## 测试结果

- 命令：`mvn -pl hsweb-core -Dtest=FastBeanCopierTest#testRecordCopy test`
  - 单元测试：`1 passed, 0 failed, 0 skipped`
- 命令：`mvn -pl hsweb-core -Dtest=FastBeanCopierTest test`
  - 单元测试：`14 passed, 0 failed, 0 skipped`
- 命令：`mvn -pl hsweb-core test`
  - 单元测试：`62 passed, 0 failed, 0 skipped`
- 新增/更新测试：`FastBeanCopierTest#testRecordCopy` 覆盖 Map/bean/record 与 nested record、集合泛型、ignore、缺省值复制路径。
- 集成测试：不适用；未涉及数据库、消息、事件、协议、跨模块边界、外部依赖或启动装配。
- 压力测试：不适用；record 支持为构造路径补齐，本次未新增性能压测要求。
- 覆盖率（执行 `mvn -pl hsweb-core test` 后 JaCoCo）：
  - hsweb-core overall line `52.04%`, branch `49.52%`
  - `FastBeanCopier` line `87.96%`, branch `76.15%`

## 文档同步情况

- 已同步：无长期文档需要同步。
- 未同步：README 未修改；FastBeanCopier 对外用法无长期总览变更。
- 说明：测试证据放在 PR / CI，未新增独立任务流水文档。

## 风险与说明

- 影响范围：`hsweb-core` 的 FastBeanCopier 复制和转换路径。
- 注释 / 公共契约：已补 `RecordCopier` 契约说明；未破坏既有 `Copier` 原地写入契约。
- 链路追踪 / 可观测性：不涉及；本次为基础工具能力增强。
- MBean / 运维可观测性：不涉及；未新增常驻运维对象。
- 未覆盖场景：未单独做性能压测；本次用生成并缓存 `RecordCopier` 避免每次 copy 反射构造。
- 已知限制：record 作为 target 时无法原地写入已有实例，当前语义为重建并返回新 record 实例。
